### PR TITLE
Fix: Training Import Error, SSL Certificate Issues & Documentation

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/disease-predictor.iml
+++ b/.idea/disease-predictor.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.13 (disease-predictor)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 (disease-predictor)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/disease-predictor.iml" filepath="$PROJECT_DIR$/.idea/disease-predictor.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/DiseaseDetectionApp/README.md
+++ b/DiseaseDetectionApp/README.md
@@ -135,7 +135,7 @@ DiseaseDetectionApp/
 │   ├── plant/                  # Plant diseases
 │   ├── human/                  # Human diseases
 │   └── animal/                 # Animal diseases
-├── train_disease_classifier.py # Model training script
+├── train_disease_classifier.py # Model training script (use run_train.sh)
 ├── predict_disease.py          # Disease prediction script
 ├── comprehensive_test.py       # Comprehensive test suite
 ├── setup.py                    # Py2app setup script

--- a/DiseaseDetectionApp/run_train.sh
+++ b/DiseaseDetectionApp/run_train.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Script to run the disease classifier training with correct environment and SSL fix
+
+# Ensure we are in the script's directory
+cd "$(dirname "$0")"
+
+# Path to venv
+VENV_PATH="../venv"
+
+if [ ! -d "$VENV_PATH" ]; then
+    echo "Error: Virtual environment not found at $VENV_PATH"
+    echo "Please ensure you have set up the environment."
+    exit 1
+fi
+
+PYTHON_EXEC="$VENV_PATH/bin/python"
+
+# Check if certifi is installed and set SSL_CERT_FILE
+if $PYTHON_EXEC -c "import certifi" &> /dev/null; then
+    export SSL_CERT_FILE=$($PYTHON_EXEC -m certifi)
+    echo "Using certificates from: $SSL_CERT_FILE"
+else
+    echo "Warning: certifi not found. SSL errors may occur."
+fi
+
+echo "Starting training..."
+$PYTHON_EXEC train_disease_classifier.py

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ If you want to train your own model:
 ```bash
 cd DiseaseDetectionApp
 python train_disease_classifier.py
+# Or if you encounter SSL errors:
+./run_train.sh
 ```
 
 The pre-trained model is included, so this step is optional.
@@ -231,7 +233,7 @@ cd DiseaseDetectionApp
 python predict_disease.py path/to/image.jpg
 
 # Train custom model
-python train_disease_classifier.py
+./run_train.sh
 
 # Run tests
 python test_disease_detection.py
@@ -529,7 +531,7 @@ pip install google-api-python-client
 
 ```bash
 cd DiseaseDetectionApp
-python train_disease_classifier.py
+./run_train.sh
 ```
 </details>
 


### PR DESCRIPTION
## Summary of Changes
- **Fixed ImportError:** The training script was failing to import  because it was running with the system Python. It now correctly uses the virtual environment.
- **Fixed SSL Error:** Added  support to handle `[SSL: CERTIFICATE_VERIFY_FAILED]` errors on macOS/Windows.
- **New Helper Script:** Created `run_train.sh` to automatically set up the environment and SSL certificates before training.
- **Documentation:** Updated `README.md` and `DiseaseDetectionApp/README.md` to reference the new `run_train.sh` script and troubleshooting steps.

## How to Test
1. Clone the branch.
2. Run `./DiseaseDetectionApp/run_train.sh`.
3. Verify that training starts and the model downloads without SSL errors.